### PR TITLE
Making sure the required number of bytes are read

### DIFF
--- a/pkg/port/iscsit/conn.go
+++ b/pkg/port/iscsit/conn.go
@@ -17,6 +17,7 @@ limitations under the License.
 package iscsit
 
 import (
+	"io"
 	"net"
 	"sort"
 	"sync"
@@ -122,7 +123,7 @@ func (c *iscsiConnection) init() {
 
 func (c *iscsiConnection) readData(size int) ([]byte, int, error) {
 	var buf = make([]byte, size)
-	length, err := c.conn.Read(buf)
+	length, err := io.ReadFull(c.conn, buf)
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
#46 Read was returning without filling the complete buffer allocated. In some cases, Basic Header Segment (48 bytes) was not being read completely.