### PR TITLE
MODE SENSE: ALLOCATION LENGTH shouldn't affect a size in response

### DIFF
--- a/pkg/scsi/sbc.go
+++ b/pkg/scsi/sbc.go
@@ -101,7 +101,7 @@ func (sbc SBCSCSIDeviceProtocol) InitLu(lu *api.SCSILu) error {
 	// Disconnect page
 	pages = append(pages, api.ModePage{2, 0, 14, []byte{0x80, 0x80, 0, 0xa, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}})
 	// Caching Page
-	pages = append(pages, api.ModePage{8, 0, 18, []byte{0x14, 0, 0xff, 0xff, 0, 0, 0xff, 0xff, 0xff, 0xff, 0x80, 0x14, 0, 0, 0, 0, 0, 0, 0x4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}})
+	pages = append(pages, api.ModePage{8, 0, 18, []byte{0x14, 0, 0xff, 0xff, 0, 0, 0xff, 0xff, 0xff, 0xff, 0x80, 0x14, 0, 0, 0, 0, 0, 0}})
 
 	// Control page
 	pages = append(pages, api.ModePage{0x0a, 0, 10, []byte{2, 0x10, 0, 0, 0, 0, 0, 0, 2, 0, 0x08, 0, 0, 0, 0, 0, 0, 0}})

--- a/pkg/scsi/spc.go
+++ b/pkg/scsi/spc.go
@@ -476,9 +476,9 @@ func SPCModeSense(host int, cmd *api.SCSICommand) api.SAMStat {
 		asc            = ASC_INVALID_FIELD_IN_CDB
 		data           []byte
 		allocLen       uint32
-		remainLen      uint32
 		i              uint32
 	)
+
 	if dbd == 0 {
 		blkDesctionLen = 8
 	}
@@ -499,22 +499,15 @@ func SPCModeSense(host int, cmd *api.SCSICommand) api.SAMStat {
 			data = append(data, 0x00)
 		}
 	}
-	remainLen = allocLen - uint32(len(data))
-	if dbd == 0 && remainLen >= 8 {
+	if dbd == 0 {
 		data = append(data, cmd.Device.ModeBlockDescriptor...)
 	}
 	if pcode == 0x3f {
 		for _, pg := range cmd.Device.ModePages {
 			if pg.SubPageCode == 0 {
-				if remainLen < 2+uint32(pg.Size) {
-					break
-				}
 				data = append(data, pg.PageCode)
 				data = append(data, pg.Size)
 			} else {
-				if remainLen < 4+uint32(pg.Size) {
-					break
-				}
 				data = append(data, pg.PageCode|0x40)
 				data = append(data, pg.SubPageCode)
 				data = append(data, (pg.Size>>8)&0xff)
@@ -537,27 +530,24 @@ func SPCModeSense(host int, cmd *api.SCSICommand) api.SAMStat {
 		if pg == nil {
 			goto sense
 		}
-		if remainLen >= 2+uint32(pg.Size) {
-			if pg.SubPageCode == 0 {
-				data = append(data, pg.PageCode)
-				data = append(data, pg.Size)
-				if pctrl == 1 {
-					data = append(data, pg.Data[pg.Size:]...)
-				} else {
-					data = append(data, pg.Data[:pg.Size]...)
-				}
-			} else if remainLen >= 4+uint32(pg.Size) {
-				data = append(data, pg.PageCode|0x40)
-				data = append(data, pg.SubPageCode)
-				data = append(data, (pg.Size>>8)&0xff)
-				data = append(data, pg.Size&0xff)
-				if pctrl == 1 {
-					data = append(data, pg.Data[pg.Size:]...)
-				} else {
-					data = append(data, pg.Data[:pg.Size]...)
-				}
+		if pg.SubPageCode == 0 {
+			data = append(data, pg.PageCode)
+			data = append(data, pg.Size)
+			if pctrl == 1 {
+				data = append(data, pg.Data[pg.Size:]...)
+			} else {
+				data = append(data, pg.Data[:pg.Size]...)
 			}
-
+		} else {
+			data = append(data, pg.PageCode|0x40)
+			data = append(data, pg.SubPageCode)
+			data = append(data, (pg.Size>>8)&0xff)
+			data = append(data, pg.Size&0xff)
+			if pctrl == 1 {
+				data = append(data, pg.Data[pg.Size:]...)
+			} else {
+				data = append(data, pg.Data[:pg.Size]...)
+			}
 		}
 	}
 	if mode6 {
@@ -569,8 +559,8 @@ func SPCModeSense(host int, cmd *api.SCSICommand) api.SAMStat {
 		data[6] = uint8(blkDesctionLen >> 8)
 		data[7] = uint8(blkDesctionLen)
 	}
-	if rlen := uint32(len(data)); rlen < allocLen {
-		cmd.InSDBBuffer.Resid = rlen
+	if rlen := uint32(len(data)); rlen > allocLen {
+		cmd.InSDBBuffer.Resid = allocLen
 	}
 	copy(cmd.InSDBBuffer.Buffer, data)
 	return api.SAMStatGood


### PR DESCRIPTION
See SCSI Command Manual (2.2.6):
> The allocation length is used to limit the maximum amount of variable length data (e.g., mode data, log data, diagnostic data) returned to an application client. If the information being transferred to the Data-In Buffer includes fields containing counts of the number of bytes in some or all of the data, then the contents of these fields shall not be altered to reflect the truncation, if any, that results from an insufficient ALLOCATION LENGTH value, unless this manual describes the Data-In Buffer format states otherwise.

Linux scsi driver sends the first request with len = 4 and the next request with a length known from a response:
https://github.com/torvalds/linux/blob/master/drivers/scsi/sd.c#L2668-L2682

Before this PR linux couldn't read the Caching page:
```
[1186194.419206] sd 6:0:0:0: [sdc] 204800 512-byte logical blocks: (105 MB/100 MiB)
[1186194.419208] sd 6:0:0:0: [sdc] 4096-byte physical blocks
[1186194.419253] sd 6:0:0:0: [sdc] Write Protect is off
[1186194.419254] sd 6:0:0:0: [sdc] Mode Sense: 03 00 10 08
[1186194.419362] sd 6:0:0:0: [sdc] No Caching mode page found
[1186194.419364] sd 6:0:0:0: [sdc] Assuming drive cache: write through
[1186194.426756] sd 6:0:0:0: [sdc] Attached SCSI disk
```

After the PR caching modes are being read successfully:
```
[1186524.264557] sd 6:0:0:0: [sdc] 204800 512-byte logical blocks: (105 MB/100 MiB)
[1186524.264558] sd 6:0:0:0: [sdc] 4096-byte physical blocks
[1186524.264631] sd 6:0:0:0: [sdc] Write Protect is off
[1186524.264632] sd 6:0:0:0: [sdc] Mode Sense: 67 00 10 08
[1186524.264750] sd 6:0:0:0: [sdc] Write cache: enabled, read cache: enabled, supports DPO and FUA
[1186524.271044] sd 6:0:0:0: [sdc] Attached SCSI disk
```