### PR TITLE
move cephstore to a separate package

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/gostor/gotgt/pkg/port/iscsit"
 	"github.com/gostor/gotgt/pkg/scsi"
 	_ "github.com/gostor/gotgt/pkg/scsi/backingstore"
+	_ "github.com/gostor/gotgt/pkg/scsi/backingstore/cephstore"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/pkg/scsi/backingstore/cephstore/cephstore_linux.go
+++ b/pkg/scsi/backingstore/cephstore/cephstore_linux.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package backingstore
+package cephstore
 
 import (
 	"fmt"


### PR DESCRIPTION
I moved cephstore to a separate package. It is not required now to build it if you are not using it.