### PR TITLE
set max unmap block descriptor count to a feasible value

### DIFF
--- a/pkg/scsi/spc.go
+++ b/pkg/scsi/spc.go
@@ -198,7 +198,7 @@ func InquiryPage0xB0(host int, cmd *api.SCSICommand) (*bytes.Buffer, uint16) {
 
 	if cmd.Device.Attrs.ThinProvisioning {
 		maxUnmapLbaCount = 0xFFFFFFFF
-		maxUnmapBlockDescriptorCount = 0xFFFFFFFF
+		maxUnmapBlockDescriptorCount = 16
 	}
 
 	//byte 0


### PR DESCRIPTION
open-iscsi test suite fails to handle such a big count.