### PR TITLE
Add ability to build gotgt without cgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ before_script:
 
 script:
    - cd ${TRAVIS_BUILD_DIR}
+   # Try a build without cgo first
+   - make build-nocgo
+   - make clean
+   # Now build with cgo and cephstore.
    - make
    - hack/verify-gofmt.sh
    - go test -v ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ all: init build
 build: init
 	go build -o ${BIN_DIR}/gotgt gotgt.go
 
+build-nocgo: init
+	CGO_ENABLED=0 go build -o ${BIN_DIR}/gotgt gotgt.go
+
 verify:
 	hack/verify-gofmt.sh
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -29,7 +29,6 @@ import (
 	_ "github.com/gostor/gotgt/pkg/port/iscsit"
 	"github.com/gostor/gotgt/pkg/scsi"
 	_ "github.com/gostor/gotgt/pkg/scsi/backingstore"
-	_ "github.com/gostor/gotgt/pkg/scsi/backingstore/cephstore"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/daemon_cgo.go
+++ b/cmd/daemon_cgo.go
@@ -1,0 +1,22 @@
+// Copyright 2016 The GoStor Authors All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Only include cephstore when building with cgo.
+// +build cgo
+
+package cmd
+
+import (
+	_ "github.com/gostor/gotgt/pkg/scsi/backingstore/cephstore"
+)


### PR DESCRIPTION
Would like to be able to just use the file backing store.