### PR TITLE
Add flag to disable login on multiple hosts

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -37,22 +37,24 @@ func newDaemonCommand(cli *client.Client) *cobra.Command {
 	var host string
 	var driver string
 	var logLevel string
+	var blockMultipleHosts bool
 	var cmd = &cobra.Command{
 		Use:   "daemon",
 		Short: "Setup a daemon",
 		Long:  `Setup the Gotgt's daemon`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return createDaemon(host, driver, logLevel)
+			return createDaemon(host, driver, logLevel, blockMultipleHosts)
 		},
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&logLevel, "log", "info", "Log level of SCSI target daemon")
 	flags.StringVar(&host, "host", "tcp://127.0.0.1:23457", "Host for SCSI target daemon")
 	flags.StringVar(&driver, "driver", "iscsi", "SCSI low level driver")
+	flags.BoolVar(&blockMultipleHosts, "block-multiple-hosts", false, "Disable login from multiple hosts")
 	return cmd
 }
 
-func createDaemon(host, driver, level string) error {
+func createDaemon(host, driver, level string, blockMultipleHosts bool) error {
 	switch level {
 	case "info":
 		log.SetLevel(log.InfoLevel)
@@ -86,6 +88,10 @@ func createDaemon(host, driver, level string) error {
 
 	for tgtname := range config.ISCSITargets {
 		targetDriver.NewTarget(tgtname, config)
+	}
+
+	if blockMultipleHosts {
+		targetDriver.EnableBlockMultipleHostLogin()
 	}
 
 	// comment this to avoid concurrent issue

--- a/pkg/scsi/drivers.go
+++ b/pkg/scsi/drivers.go
@@ -31,6 +31,7 @@ type SCSITargetDriver interface {
 	Resize(uint64) error
 	Stats() Stats
 	SetClusterIP(string)
+	EnableBlockMultipleHostLogin()
 }
 
 type Stats struct {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds a new flag to enable blocking of login from multiple hosts. This feature is required for implement a RWO volume in kubernetes environment where even though we mention RWO in the persistent volume still in some scenarios multiple pods on different hosts can mount the same volume,  ref : https://github.com/openebs/openebs/issues/3404 . 
This can be prevented from the CSI drivers, but we can not guarantee that pods will not mount the same volume in some edge cases. It is good to reject a new login when a connection already exists to ensure there is no data corruption.

By default, this feature is disabled and can be enabled when creating a new Target object using `EnableBlockMultipleHostLogin`